### PR TITLE
Fix Slack SSL connection

### DIFF
--- a/lib/redmine_mattermost/listener.rb
+++ b/lib/redmine_mattermost/listener.rb
@@ -152,10 +152,11 @@ class MattermostListener < Redmine::Hook::Listener
 		begin
 			client = HTTPClient.new
 			client.ssl_config.cert_store.set_default_paths
-			client.ssl_config.ssl_version = "SSLv23"
+			client.ssl_config.ssl_version = :auto
 			client.post_async url, {:payload => params.to_json}
-		rescue
-			# Bury exception if connection error
+		rescue Exception => e
+			logger.warn("cannot connect to #{url}")
+			logger.warn(e)
 		end
 	end
 


### PR DESCRIPTION
This is a backport from sciyoshi/redmine-slack:

https://github.com/sciyoshi/redmine-slack/commit/349362f4cb402008814d4dd256114fb38a928917

---

Make HTTPClient auto-negotiate SSL supported ciphers - forget about :SSLV23 which are refused by most servers now.
- log exceptions that could occur
- remove comment
