### PR TITLE
downcase channel name and replace space by hypen

### DIFF
--- a/lib/redmine_mattermost/listener.rb
+++ b/lib/redmine_mattermost/listener.rb
@@ -202,6 +202,11 @@ private
 			Setting.plugin_redmine_mattermost[:channel],
 		].find{|v| v.present?}
 
+                # Change channel name to regular mattermost name (' ' -> '-' and all lowercase)
+                val = val.downcase!
+                val = val.split(' ').join('-') if val.include?(' ')
+
+
 		# Channel name '-' or empty '' is reserved for NOT notifying
 		return [] if val.to_s == ''
 		return [] if val.to_s == '-'

--- a/lib/redmine_mattermost/listener.rb
+++ b/lib/redmine_mattermost/listener.rb
@@ -202,9 +202,9 @@ private
 			Setting.plugin_redmine_mattermost[:channel],
 		].find{|v| v.present?}
 
-                # Change channel name to regular mattermost name (' ' -> '-' and all lowercase)
-                val = val.downcase!
-                val = val.split(' ').join('-') if val.include?(' ')
+		# Change channel name to regular mattermost name (' ' -> '-' and all lowercase)
+		val = val.downcase!
+		val = val.split(' ').join('-') if val.include?(' ')
 
 		# Channel name '-' or empty '' is reserved for NOT notifying
 		return [] if val.to_s == ''

--- a/lib/redmine_mattermost/listener.rb
+++ b/lib/redmine_mattermost/listener.rb
@@ -206,7 +206,6 @@ private
                 val = val.downcase!
                 val = val.split(' ').join('-') if val.include?(' ')
 
-
 		# Channel name '-' or empty '' is reserved for NOT notifying
 		return [] if val.to_s == ''
 		return [] if val.to_s == '-'


### PR DESCRIPTION
Hello,
I lost one afternoon by pluging the plugin to a mattermost channel named "Redmine Bot" and this doesn't work... It's because all channels names are downcase and space are replaced by hypens ("Redmine Bot" -> "redmine-bot"). So, there is a little patch :)