### PR TITLE
fix so plugin works for Redmine 3.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ channel.
 
 Redmine Supported versions: 
 
-version 0.6 for Redmine versions: 4.0.x.
+version 0.6 for Redmine versions: 4.0.x and 3.4.x
 
 version 0.5 for Redmine versions: 2.0.x - 3.3.x.
 

--- a/init.rb
+++ b/init.rb
@@ -1,7 +1,5 @@
 require 'redmine'
 
-require_dependency 'redmine_mattermost/listener'
-
 Redmine::Plugin.register :redmine_mattermost do
 	name 'Redmine Mattermost'
 	author 'AltSol'
@@ -24,6 +22,7 @@ Redmine::Plugin.register :redmine_mattermost do
 end
 
 ActiveSupport::Reloader.to_prepare do
+    require_dependency 'redmine_mattermost/listener'
 	require_dependency 'issue'
 	unless Issue.included_modules.include? RedmineMattermost::IssuePatch
 		Issue.send(:include, RedmineMattermost::IssuePatch)


### PR DESCRIPTION
With this fix it works in my Redmine 3.4.x installation as well.
Untested on Redmine 4.x though - but I assume it should be no matter.